### PR TITLE
Remove stray sampler properties from textures

### DIFF
--- a/Shaders/Glamayre_Fast_Effects.fx
+++ b/Shaders/Glamayre_Fast_Effects.fx
@@ -1112,19 +1112,12 @@ texture HBlurTex {
     Width = FAKE_GI_WIDTH ;
     Height = FAKE_GI_HEIGHT ;
     Format = RGBA16F;
-	AddressU = BORDER;
-	AddressV = BORDER;
-	AddressW = BORDER;
 };
 
 texture VBlurTex {
     Width = FAKE_GI_WIDTH ;
     Height = FAKE_GI_HEIGHT ;
     Format = RGBA16F;
-	AddressU = BORDER;
-	AddressV = BORDER;
-	AddressW = BORDER;
-
 };
 
 sampler HBlurSampler {


### PR DESCRIPTION
Provides compatibility with ReShade 5.9.0